### PR TITLE
Add module entry point for .es.js dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Adam Miskiewicz <adam@sk3vy.com>",
   "license": "MIT",
   "main": "./dist/module/index.js",
+  "module": "./dist/index.es.js",
   "types": "./dist/module/index.d.ts",
   "scripts": {
     "dev": "concurrently \"yarn watch\" \"cd demos && yarn start\"",


### PR DESCRIPTION
Lovely module! I just went to include it using unpkg's `?module` feature, but despite there being a good .es.js dist generated, it isn't mentioned by the package.json. I've added that entry to the package in this PR, which allows people to easily use dynamic or static `import` with wobble.