### PR TITLE
Jank-free rendering & shared tickers (WIP)

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -6,6 +6,7 @@
         <h1>Demos</h1>
         <ul>
           <li><a href="./1-chat-heads/index.html">Chat Heads</a></li>
+          <li><a href="./squares/index.html">Squares</a></li>
         </ul>
     </body>
 </html>

--- a/demos/squares/index.html
+++ b/demos/squares/index.html
@@ -1,0 +1,15 @@
+<html>
+    <head>
+        <title>Squares</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+        <style>
+        * {
+          margin: 0;
+        }
+        </style>
+    </head>
+    <body>
+        <div id="app"></div>
+        <script src="./index.tsx"></script>
+    </body>
+</html>

--- a/demos/squares/index.tsx
+++ b/demos/squares/index.tsx
@@ -1,22 +1,13 @@
+'use strict'
+
 import { Spring } from "../../dist/module"
 
 
-const COUNT = 50
-const squares = []
-
-const canvas = document.createElement('canvas')
-const ctx = canvas.getContext('2d')
-
-canvas.style.width = canvas.style.height = '100%'
-document.body.appendChild(canvas)
-resizeCanvasToDisplaySize(canvas)
-
-
 class Square {
-  constructor(i) {
+  constructor(i, x, y) {
     this.i = i
-    this.x = Math.random() * canvas.width
-    this.y = Math.random() * canvas.height
+    this.x = x
+    this.y = y
     this.color = '#'+Math.random().toString(16).substr(2,6)
     this.springs = {
       x: new Spring({fromValue: this.x, raf: false}), // x
@@ -37,6 +28,52 @@ class Square {
   }
 }
 
+class Renderer {
+  constructor() {
+
+    const COUNT = 1000
+    const canvas = document.createElement('canvas')
+    const squares = []
+
+    canvas.style.width = canvas.style.height = '100%'
+    document.body.appendChild(canvas)
+    resizeCanvasToDisplaySize(canvas)
+
+    for(var i = 0; i < COUNT; i++) {
+      squares.push(new Square(i, Math.random() * canvas.width, Math.random() * canvas.height))
+    }
+
+    this.squares = squares
+    this.canvas = canvas
+    this.ctx = canvas.getContext('2d')
+
+  }
+
+  draw = () => {
+    const now = Date.now()
+    const {canvas, squares, ctx} = this
+
+    resizeCanvasToDisplaySize(canvas)
+
+    const {width, height} = canvas
+
+    ctx.clearRect(0, 0, width, height)
+
+    const index = Math.floor(squares.length*Math.random())
+    squares[index].setPosition(Math.random() * canvas.width, Math.random() * canvas.height)
+
+    for(var i = 0; i < squares.length; i++) {
+      const square = squares[i]
+      square.tick(now)
+      ctx.fillStyle = square.color
+      ctx.fillRect(square.x, square.y, 10, 10)
+    }
+
+    requestAnimationFrame(this.draw)
+  }
+
+}
+
 function resizeCanvasToDisplaySize(canvas) {
   let w = (canvas.clientWidth*devicePixelRatio) | 0
   let h = (canvas.clientHeight*devicePixelRatio) | 0
@@ -46,34 +83,5 @@ function resizeCanvasToDisplaySize(canvas) {
   }
 }
 
-function draw() {
-  const now = Date.now()
-  resizeCanvasToDisplaySize(canvas)
-  const width = canvas.width
-  const height = canvas.height
-  ctx.clearRect(0, 0, width, height)
-  for(var i = 0; i < squares.length; i++) {
-    const square = squares[i]
-    square.tick(now)
-    ctx.fillStyle = square.color
-    ctx.fillRect(square.x, square.y, 50, 50)
-  }
-  requestAnimationFrame(draw)
-}
-
-setInterval(() => {
-  randomize()
-}, 100)
-
-function randomize() {
-  squares[Math.floor(squares.length*Math.random())]
-    .setPosition(Math.random() * canvas.width, Math.random() * canvas.height)
-}
-
-for(var i = 0; i < COUNT; i++) {
-  squares.push(new Square(i))
-}
-
-draw()
-
-window.randomize = randomize
+const renderer = new Renderer()
+renderer.draw()

--- a/demos/squares/index.tsx
+++ b/demos/squares/index.tsx
@@ -9,14 +9,28 @@ class Square {
     this.x = x
     this.y = y
     this.color = '#'+Math.random().toString(16).substr(2,6)
+
+    // raf
+    //this.springs = {
+      //x: new Spring({fromValue: this.x}), // x
+      //y: new Spring({fromValue: this.y})  // y
+    //}
+
+    // no raf
     this.springs = {
       x: new Spring({fromValue: this.x, raf: false}), // x
       y: new Spring({fromValue: this.y, raf: false})  // y
     }
+
     this.springs.x.onUpdate(s => this.x = s.currentValue)
     this.springs.y.onUpdate(s => this.y = s.currentValue)
   }
   setPosition(x, y) {
+    // raf
+    //this.springs.x.updateConfig({toValue: x}).start()
+    //this.springs.y.updateConfig({toValue: y}).start()
+
+    // no raf
     this.springs.x.setValue(x);
     this.springs.y.setValue(y);
   }
@@ -64,7 +78,10 @@ class Renderer {
 
     for(var i = 0; i < squares.length; i++) {
       const square = squares[i]
+
+      // with no raf, have to manually advance simulation. comment out if using raf
       square.tick(now)
+
       ctx.fillStyle = square.color
       ctx.fillRect(square.x, square.y, 10, 10)
     }

--- a/demos/squares/index.tsx
+++ b/demos/squares/index.tsx
@@ -1,0 +1,79 @@
+import { Spring } from "../../dist/module"
+
+
+const COUNT = 50
+const squares = []
+
+const canvas = document.createElement('canvas')
+const ctx = canvas.getContext('2d')
+
+canvas.style.width = canvas.style.height = '100%'
+document.body.appendChild(canvas)
+resizeCanvasToDisplaySize(canvas)
+
+
+class Square {
+  constructor(i) {
+    this.i = i
+    this.x = Math.random() * canvas.width
+    this.y = Math.random() * canvas.height
+    this.color = '#'+Math.random().toString(16).substr(2,6)
+    this.springs = {
+      x: new Spring({fromValue: this.x, raf: false}), // x
+      y: new Spring({fromValue: this.y, raf: false})  // y
+    }
+    this.springs.x.onUpdate(s => this.x = s.currentValue)
+    this.springs.y.onUpdate(s => this.y = s.currentValue)
+  }
+  setPosition(x, y) {
+    this.springs.x.setValue(x);
+    this.springs.y.setValue(y);
+  }
+  tick(now) {
+    this.springs.x._advanceSpringToTime(now, true)
+    this.springs.y._advanceSpringToTime(now, true)
+    //this.springs.x._step()
+    //this.springs.x._step()
+  }
+}
+
+function resizeCanvasToDisplaySize(canvas) {
+  let w = (canvas.clientWidth*devicePixelRatio) | 0
+  let h = (canvas.clientHeight*devicePixelRatio) | 0
+  if (canvas.width != w || canvas.height != h) {
+    canvas.width = w
+    canvas.height = h
+  }
+}
+
+function draw() {
+  const now = Date.now()
+  resizeCanvasToDisplaySize(canvas)
+  const width = canvas.width
+  const height = canvas.height
+  ctx.clearRect(0, 0, width, height)
+  for(var i = 0; i < squares.length; i++) {
+    const square = squares[i]
+    square.tick(now)
+    ctx.fillStyle = square.color
+    ctx.fillRect(square.x, square.y, 50, 50)
+  }
+  requestAnimationFrame(draw)
+}
+
+setInterval(() => {
+  randomize()
+}, 100)
+
+function randomize() {
+  squares[Math.floor(squares.length*Math.random())]
+    .setPosition(Math.random() * canvas.width, Math.random() * canvas.height)
+}
+
+for(var i = 0; i < COUNT; i++) {
+  squares.push(new Square(i))
+}
+
+draw()
+
+window.randomize = randomize

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export interface SpringConfig {
   overshootClamping: boolean; // False when overshooting is allowed, true when it is not. Defaults to false.
   restVelocityThreshold: number; // When spring's velocity is below `restVelocityThreshold`, it is at rest. Defaults to .001.
   restDisplacementThreshold: number; // When the spring's displacement (current value) is below `restDisplacementThreshold`, it is at rest. Defaults to .001.
+  [index: string]: any;
 }
 
 export type PartialSpringConfig = Partial<SpringConfig>;
@@ -158,16 +159,14 @@ export class Spring {
 
     this._advanceSpringToTime(Date.now());
 
-    const baseConfig = {
-      fromValue: this._currentValue,
-      initialVelocity: this._currentVelocity
-    };
+    this._config.fromValue = this._currentValue;
+    this._config.initialVelocity = this._currentVelocity;
 
-    this._config = {
-      ...this._config,
-      ...baseConfig,
-      ...updatedConfig
-    };
+    for (const key in updatedConfig) {
+      if (this._config.hasOwnProperty(key)) {
+        this._config[key] = updatedConfig[key as keyof SpringConfig];
+      }
+    }
 
     this._reset();
 


### PR DESCRIPTION
I added a `setValue` function that acts as sugar
for updating config and starting. This is somewhat akin
to `setEndValue` in rebound. Name of method is totally
up for debate. 

Second, I added a `raf` config option (again, name up for
debate) that stops `_step()` from registering its own
requestAnimationFrames. With `raf: false` all spring
advancing must be done manually.

That said, I mangled the living hell out of `_step`
and `advanceSpringToTime` in order to get this to work.

It needs some cleaning up. Perhaps `_step` becomes
what `_advanceSpring` is now? Usually in GL land
step/tick functions are called by your main draw loop
to do whatever time-based advancing they need to do, so there'd
be some parity to existing convetions that way.

Finally, check out the squares demo I added (again it's messy).
If you watch the performance monitor heap allocation remains
constant and there's only a single raf frame :thumbsup: